### PR TITLE
Fixed a babel parse error

### DIFF
--- a/app/initializers/-ember-turbolinks.js
+++ b/app/initializers/-ember-turbolinks.js
@@ -41,8 +41,8 @@ let ServerRenderedView = Ember.View.extend({
   },
 
   _handleResponse(html) {
-    let html = this._extractHTML(this.turboSelector, html)
-    this.$().html(html);
+    let extractHTML = this._extractHTML(this.turboSelector, html);
+    this.$().html(extractHTML);
     this._setupEvents();
   },
 


### PR DESCRIPTION
A small update to fix the issue. 

```
14:49:36 TypeError: riviera/initializers/-ember-turbolinks.js: Line 44: Duplicate declaration "html"
14:49:36   42 | 
14:49:36   43 |   _handleResponse(html) {
14:49:36 > 44 |     let html = this._extractHTML(this.turboSelector, html)
14:49:36      |         ^
14:49:36   45 |     this.$().html(html);
14:49:36   46 |     this._setupEvents();
14:49:36   47 |   },
```
